### PR TITLE
updated output schema

### DIFF
--- a/fortinet-fortiddos/info.json
+++ b/fortinet-fortiddos/info.json
@@ -1318,7 +1318,7 @@
         },
         {
           "condition": "{{this['subtype'] === 'top_attacks' || this['subtype'] === 'top_attacked_dns_servers' || this['subtype'] === 'top_attacked_dns_anomalies'}}",
-          "output_schema": []
+          "output_schema": {}
         }
       ]
     },


### PR DESCRIPTION
 At the time of build rpm with build_online_docs param gets "IndexError: list index out of range" error for an empty list of output schema. 