### PR TITLE
bug fixes

### DIFF
--- a/fortinet-fortiddos/add_lq.py
+++ b/fortinet-fortiddos/add_lq.py
@@ -18,6 +18,7 @@ def add_lq(config, params):
     request_body = {'data': data}
     rq = json.dumps(request_body)
     endpoint = "/api/v2/legitimate_queries/"
+    ddos_conn.headers.update({'Content-Type': 'application/json'})
     api_response = ddos_conn.make_request(method='POST', endpoint=endpoint, data=rq)
     return {"status": "success",
             "message": "{0} created successfully.".format(query)} if api_response == '' else {

--- a/fortinet-fortiddos/constants.py
+++ b/fortinet-fortiddos/constants.py
@@ -7,7 +7,7 @@ LOGGER_NAME = 'fortinet-fortiddos'
 CONVERT_LIST = ['alt-spp-enable', 'acl-enable', 'destination-port', 'dscp', 'fragment', 'protocol', 'source-ip',
                 'source-port', 'tcp-control-flag', 'ttl']
 CONVERT_STR = ['destination-port-end', 'threshold-per-million', 'protocol-number', 'ttl-value', 'class', 'threshold',
-               'subnet-id']
+               'subnet-id', 'destination-port-start', 'source-port-start', 'source-port-end', 'dscp-value']
 PARAM_MAPPING = {
     True: 'enable',
     False: 'disable',
@@ -48,7 +48,7 @@ RESOURCE_MAPPING = {
     "HTTP Service Ports": "ddos_global_http_service_ports",
     "UDP Service Ports": "ddos_global_udp_service_ports",
     "Signaling": "ddos_global_sp_fdd",
-    "Service Provider Address": "ddos_global_service_provider_address",
+    "GRE Tunnel Endpoint": "ddos_global_service_provider_address",
 
     "Local Address Config": "ddos_global_firewall_local_address",
     "Local Address Config IPv6": "ddos_global_firewall_local_address6",
@@ -80,3 +80,13 @@ RESOURCE_MAPPING = {
     "Settings": "sysglobal",
     "Certificate": "certificate_local"
 }
+
+error_msg = {
+    401: 'Authentication failed due to invalid credentials',
+    404: 'Not Found',
+    405: 'Method not allowed',
+    "ssl_error": 'SSL certificate validation failed',
+    'time_out': 'The request timed out while trying to connect to the remote server',
+}
+
+resources = ["Access Control List", "Address Config", "Address Config IPv6"]

--- a/fortinet-fortiddos/delete_distress_acl.py
+++ b/fortinet-fortiddos/delete_distress_acl.py
@@ -6,13 +6,22 @@
 from connectors.core.connector import get_logger, ConnectorError
 from .constants import LOGGER_NAME
 from .utils import MakeRestApiCall
-
 logger = get_logger(LOGGER_NAME)
 
 
+def get_distress_acl(ddos_conn, distress_acl_name):
+    endpoint = "/api/v2/distress_acl/"
+    acl_list = ddos_conn.make_request(endpoint=endpoint)
+    acl_exist = list(filter(lambda x: x.get('mkey') == distress_acl_name, acl_list))
+    return acl_exist
+
+
 def delete_distress_acl(config, params):
-    ddos_conn = MakeRestApiCall(config)
     distress_acl_name = params.get("name")
+    ddos_conn = MakeRestApiCall(config)
+    acl_exist = get_distress_acl(ddos_conn, distress_acl_name)
+    if not acl_exist:
+        raise ConnectorError("{0} distress ACL name not exists.".format(distress_acl_name))
     endpoint = "/api/v2/distress_acl/?{name}".format(name=distress_acl_name)
     response = ddos_conn.make_request("DELETE", endpoint=endpoint)
     logger.debug('response: {0}'.format(response))

--- a/fortinet-fortiddos/get_global_settings.py
+++ b/fortinet-fortiddos/get_global_settings.py
@@ -11,7 +11,6 @@ logger = get_logger(LOGGER_NAME)
 
 
 def get_global_settings(config, params):
-    logger.info("params: {}".format(params))
     resource_name = params.get('resource_name', None)
     if not resource_name:
         resource_name = 'ddos_global_setting'

--- a/fortinet-fortiddos/get_spp_settings.py
+++ b/fortinet-fortiddos/get_spp_settings.py
@@ -4,7 +4,7 @@
   FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
   Copyright end """
 from connectors.core.connector import get_logger, ConnectorError
-from .constants import LOGGER_NAME, RESOURCE_MAPPING
+from .constants import LOGGER_NAME, RESOURCE_MAPPING, resources
 from .utils import MakeRestApiCall
 
 logger = get_logger(LOGGER_NAME)
@@ -12,7 +12,6 @@ logger = get_logger(LOGGER_NAME)
 
 def get_spp_settings(config, params):
     resource_name = params.get('resource_name')
-    resources = ["Access Control List", "Address Config", "Address Config IPv6"]
     if resource_name in resources:
         resource_name = "SPP: {0}".format(resource_name)
     spp = params.get('spp')

--- a/fortinet-fortiddos/info.json
+++ b/fortinet-fortiddos/info.json
@@ -237,7 +237,7 @@
           "editable": true,
           "type": "json",
           "name": "parameter_name_val",
-          "tooltip": "SPP settings arguments in json format",
+          "tooltip": "Resource arguments in json format",
           "placeholder": "{\"field1\":value1, \"field2\":value2}",
           "value": {
             "inbound-operating-mode": "prevention"
@@ -326,11 +326,16 @@
       ],
       "conditional_output_schema": [
         {
-          "condition": "{{true}}",
+          "condition": "{{this['resource_name'] === 'SPP Policy Group'}}",
           "output_schema": {
             "success": "",
             "query": "",
-            "data": [],
+            "data": [
+              {
+                "mkey": "",
+                "member-list": ""
+              }
+            ],
             "message": ""
           }
         },
@@ -349,13 +354,37 @@
               }
             ]
           }
+        },
+        {
+          "condition": "{{this['resource_name'] === 'SPP Policy'}}",
+          "output_schema": {
+            "query": "",
+            "success": "",
+            "message": "",
+            "data": [
+              {
+                "spp": "",
+                "mkey": "",
+                "alt-spp": "",
+                "comment": "",
+                "subnet-id": "",
+                "threshold": "",
+                "ip-version": "",
+                "ip-addr-mask": "",
+                "alt-spp-enable": "",
+                "threshold-mbps": "",
+                "ipv6-addr-prefix": "",
+                "threshold-per-million": ""
+              }
+            ]
+          }
         }
       ]
     },
     {
       "title": "Get Settings",
       "operation": "get_settings",
-      "description": "Retrieves the internal sub-resources from settings in the FortiDDoS global settings based on the resource name you have specified.",
+      "description": "Retrieves the internal sub-resources from settings in the FortiDDoS global settings based on the resource name you have specified. The global settings are located at: Global Settings > Settings.",
       "category": "investigation",
       "annotation": "get_global_settings",
       "enabled": true,
@@ -373,9 +402,9 @@
             "HTTP Service Ports",
             "UDP Service Ports",
             "Signaling",
-            "Service Provider Address"
+            "GRE Tunnel Endpoint"
           ],
-          "description": "Select the name of the resource whose internal sub-resources you want to retrieve from settings in FortiDDoS. You can choose from the following options: HTTP Service Ports, UDP Service Ports, Signaling, Service Provider Address."
+          "description": "Select the name of the resource whose internal sub-resources you want to retrieve from settings in FortiDDoS. You can choose from the following options: HTTP Service Ports, UDP Service Ports, Signaling, GRE Tunnel Endpoint."
         }
       ],
       "output_schema": {
@@ -1171,7 +1200,7 @@
     {
       "title": "Get Attack Information",
       "operation": "get_attack_information",
-      "description": "Retrieves all attack information or specific attack information from FortiDDoS based on the SPP Name, Direction, and Period you have specified.",
+      "description": "Retrieves attack information from FortiDDoS based on the SPP name, attack subtype, direction, and period you have specified.",
       "category": "investigation",
       "annotation": "get_attack_information",
       "enabled": true,
@@ -1180,12 +1209,44 @@
           "title": "SPP",
           "type": "text",
           "name": "spp_name",
-          "required": false,
+          "required": true,
           "visible": true,
           "editable": true,
           "value": "SPP-0",
           "tooltip": "Name of the service protection profile",
           "description": "Specify the name of the Service Protection Profile (SPP) whose attack information you want to retrieve from FortiDDoS."
+        },
+        {
+          "title": "Subtype",
+          "type": "select",
+          "name": "subtype",
+          "required": true,
+          "visible": true,
+          "editable": true,
+          "value": "top_attacks",
+          "options": [
+            "top_attacks",
+            "top_attackers",
+            "top_acl_attacks",
+            "top_attacked_spps",
+            "top_attacked_acl_spps",
+            "top_attacked_subnets",
+            "top_acl_subnets",
+            "top_attacked_destinations",
+            "top_attacked_protocols",
+            "top_attacked_tcp_ports",
+            "top_attacked_udp_ports",
+            "top_attacked_icmp_type_codes",
+            "top_attacked_http_methods",
+            "top_attacked_http_cookies",
+            "top_attacked_http_referers",
+            "top_attacked_http_user_agents",
+            "top_attacked_http_hosts",
+            "top_attacked_http_urls",
+            "top_attacked_dns_servers",
+            "top_attacked_dns_anomalies"
+          ],
+          "description": "Select the name of the subtype for which you want to retrieve attack information from FortiDDoS. You can choose the following options: top_attacks, top_attackers, top_acl_attacks, top_attacked_spps, top_attacked_acl_spps, top_attacked_subnets, top_acl_subnets, top_attacked_destinations, top_attacked_protocols, top_attacked_tcp_ports, top_attacked_udp_ports, top_attacked_icmp_type_codes, top_attacked_http_methods, top_attacked_http_cookies, top_attacked_http_referers, top_attacked_http_user_agents, top_attacked_http_hosts, top_attacked_http_urls, top_attacked_dns_servers, top_attacked_dns_anomalies. The attack information located at: Log & Report > Executive Summary > DDoS Attack Log."
         },
         {
           "title": "Direction",
@@ -1218,38 +1279,6 @@
             "1 year"
           ],
           "description": "Specify the period to retrieve attack information from FortiDDoS. You can choose between 1 hour, 8 hours, 1 day, 1 week, 1 month, or 1 year."
-        },
-        {
-          "title": "Subtype",
-          "type": "select",
-          "name": "subtype",
-          "required": false,
-          "visible": true,
-          "editable": true,
-          "value": "top_attacks",
-          "options": [
-            "top_attacks",
-            "top_attackers",
-            "top_acl_attacks",
-            "top_attacked_spps",
-            "top_attacked_acl_spps",
-            "top_attacked_subnets",
-            "top_acl_subnets",
-            "top_attacked_destinations",
-            "top_attacked_protocols",
-            "top_attacked_tcp_ports",
-            "top_attacked_udp_ports",
-            "top_attacked_icmp_type_codes",
-            "top_attacked_http_methods",
-            "top_attacked_http_cookies",
-            "top_attacked_http_referers",
-            "top_attacked_http_user_agents",
-            "top_attacked_http_hosts",
-            "top_attacked_http_urls",
-            "top_attacked_dns_servers",
-            "top_attacked_dns_anomalies"
-          ],
-          "description": "Select the name of the subtype for which you want to retrieve attack information from FortiDDoS. You can choose the following options: top_attacks, top_attackers, top_acl_attacks, top_attacked_spps, top_attacked_acl_spps, top_attacked_subnets, top_acl_subnets, top_attacked_destinations, top_attacked_protocols, top_attacked_tcp_ports, top_attacked_udp_ports, top_attacked_icmp_type_codes, top_attacked_http_methods, top_attacked_http_cookies, top_attacked_http_referers, top_attacked_http_user_agents, top_attacked_http_hosts, top_attacked_http_urls, top_attacked_dns_servers, top_attacked_dns_anomalies."
         }
       ],
       "conditional_output_schema": [
@@ -1371,7 +1400,8 @@
                 "visible": true,
                 "editable": true,
                 "placeholder": "eg. 0.0.0.0/0",
-                "description": "Specify the destination IPv4 Netmask to add to the new Distress ACL in the FortiDDoS."
+                "tooltip": "Example: 192.3.2.5/24",
+                "description": "Specify the destination IPv4 Netmask to add to the new Distress ACL in the FortiDDoS. Example: 192.3.2.5/24"
               }
             ],
             "all": [
@@ -1393,7 +1423,8 @@
                 "visible": true,
                 "editable": true,
                 "value": "0.0.0.0/0",
-                "description": "Specify the destination IPv4 Netmask to add to the new Distress ACL in the FortiDDoS."
+                "tooltip": "Example: 192.3.2.5/24",
+                "description": "Specify the destination IPv4 Netmask to add to the new Distress ACL in the FortiDDoS. Example: 192.3.2.5/24"
               }
             ]
           },
@@ -1416,7 +1447,8 @@
                 "required": true,
                 "visible": true,
                 "editable": true,
-                "description": "Specify the start of the destination port that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance."
+                "tooltip": "Range: 0 - 65535",
+                "description": "Specify the start of the destination port that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance. Range: 0 - 65535"
               },
               {
                 "title": "Destination Port End",
@@ -1425,7 +1457,8 @@
                 "required": true,
                 "visible": true,
                 "editable": true,
-                "description": "Specify the end of the destination port that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance."
+                "tooltip": "Range: 0 - 65535",
+                "description": "Specify the end of the destination port that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance. Range: 0 - 65535"
               }
             ],
             "false": [
@@ -1437,7 +1470,8 @@
                 "visible": true,
                 "editable": true,
                 "value": "1000000",
-                "description": "Specify the threshold per million that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance. For example, 1000000"
+                "tooltip": "Range: 1 - 1000000",
+                "description": "Specify the threshold per million that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance. For example, 1000000 Range: 1 - 1000000"
               }
             ]
           },
@@ -1460,11 +1494,13 @@
                 "required": true,
                 "visible": true,
                 "editable": true,
-                "description": "Specify the DSCP value that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance."
+                "tooltip": "ToS Value. Range: 0 - 255",
+                "description": "Specify the DSCP(ToS) value that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance. Range: 0 - 255"
               }
             ]
           },
-          "description": "Select the DSCP option if you want to add the DSCP value information to the new Distress ACL that you are adding to the FortiDDoS appliance."
+          "tooltip": "ToS",
+          "description": "Select the DSCP(ToS) option if you want to add the DSCP value information to the new Distress ACL that you are adding to the FortiDDoS appliance."
         },
         {
           "title": "Fragment",
@@ -1512,7 +1548,8 @@
                 "required": true,
                 "visible": true,
                 "editable": true,
-                "description": "Specify the protocol number that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance."
+                "tooltip": "Range: 0 - 255",
+                "description": "Specify the protocol number that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance. Range: 0 - 255"
               }
             ]
           },
@@ -1535,7 +1572,8 @@
                 "required": true,
                 "visible": true,
                 "editable": true,
-                "description": "Specify the source IP ipv4 netmask information that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance.."
+                "tooltip": "Example: 192.3.2.5/24",
+                "description": "Specify the source IP ipv4 netmask information that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance. Example: 192.3.2.5/24"
               }
             ]
           },
@@ -1555,19 +1593,21 @@
                 "title": "Source Port Start",
                 "type": "text",
                 "name": "source-port-start",
-                "required": false,
+                "required": true,
                 "visible": true,
                 "editable": true,
-                "description": "Specify the start of the source port that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance."
+                "tooltip": "Range: 0 - 65535",
+                "description": "Specify the start of the source port that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance. Range: 0 - 65535"
               },
               {
                 "title": "Source Port End",
                 "type": "text",
                 "name": "source-port-end",
-                "required": false,
+                "required": true,
                 "visible": true,
                 "editable": true,
-                "description": "Specify the end of the source port that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance."
+                "tooltip": "Range: 0 - 65535",
+                "description": "Specify the end of the source port that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance. Range: 0 - 65535"
               }
             ]
           },
@@ -1590,7 +1630,8 @@
                 "required": false,
                 "visible": true,
                 "editable": true,
-                "description": "Specify the TCP control flag options information that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance."
+                "tooltip": "FIN SYN RST PSH ACK URG",
+                "description": "Specify the TCP control flag options information that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance. You can specify values as: FIN SYN RST PSH ACK URG"
               }
             ]
           },
@@ -1613,7 +1654,8 @@
                 "required": true,
                 "visible": true,
                 "editable": true,
-                "description": "Specify the TTL value that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance."
+                "tooltip": "Range: 0 - 255",
+                "description": "Specify the TTL value that you want to add to the new Distress ACL that you are adding to the FortiDDoS appliance. Range: 0 - 255"
               }
             ]
           },
@@ -1652,11 +1694,22 @@
     {
       "title": "Add Service Protection Profile Policy",
       "operation": "add_service_protection_profile_policy",
-      "description": "Adds a new SPP profile to the FortiDDoS appliance based on subnet ID, Mkey name, IP version, and the input parameters you have specified.",
+      "description": "Adds a new SPP Policy to the FortiDDoS appliance based on subnet ID, Mkey name, IP version, and the input parameters you have specified. The new SPP policy details are located at: Global Settings > Service Protection Profiles > SPP Policy.",
       "category": "remediation",
       "annotation": "add_service_protection_profile_policy",
       "enabled": true,
       "parameters": [
+        {
+          "title": "SPP",
+          "type": "text",
+          "name": "spp",
+          "required": true,
+          "visible": true,
+          "editable": true,
+          "value": "SPP-0",
+          "tooltip": "Name of the service protection profile",
+          "description": "Specify the name of the Service protection profile to add the new SPP policy to the FortiDDoS appliance."
+        },
         {
           "title": "Subnet ID",
           "type": "text",
@@ -1664,7 +1717,8 @@
           "required": true,
           "visible": true,
           "editable": true,
-          "description": "Specify the subnet ID to add the new SPP policy to the FortiDDoS appliance."
+          "tooltip": "Range: 1 - 2047",
+          "description": "Specify the subnet ID to add the new SPP policy to the FortiDDoS appliance. Range: 1 - 2047"
         },
         {
           "title": "MKey Name",
@@ -1673,7 +1727,8 @@
           "required": true,
           "visible": true,
           "editable": true,
-          "description": "Specify the name of the MKey Name to add the new SPP policy to the FortiDDoS appliance."
+          "tooltip": "SPP Policy Name",
+          "description": "Specify the name of the MKey (SPP Policy) to add the new SPP policy to the FortiDDoS appliance."
         },
         {
           "title": "IP Version",
@@ -1696,7 +1751,8 @@
                 "required": true,
                 "visible": true,
                 "editable": true,
-                "description": "Specify the IPv4/Netmask to add the new SPP policy to the FortiDDoS appliance."
+                "tooltip": "Example: 192.3.2.5/24",
+                "description": "Specify the IPv4/Netmask to add the new SPP policy to the FortiDDoS appliance. Example: 192.3.2.5/24"
               }
             ],
             "IPv6": [
@@ -1704,25 +1760,15 @@
                 "title": "IPv6/Prefix",
                 "type": "text",
                 "name": "ipv6-addr-prefix",
-                "required": false,
+                "required": true,
                 "visible": true,
                 "editable": true,
-                "description": "Specify the IPv6/Prefix to add the new SPP policy to the FortiDDoS appliance"
+                "tooltip": "Example: 2001:0db8:85a3:8a2e:0370::7334/64",
+                "description": "Specify the IPv6/Prefix to add the new SPP policy to the FortiDDoS appliance. Example: 2001:0db8:85a3:8a2e:0370::7334/64"
               }
             ]
           },
           "description": "Select this IP version to add the new SPP policy to the FortiDDoS appliance. You can choose between IPv4 or IPv6."
-        },
-        {
-          "title": "SPP",
-          "type": "text",
-          "name": "spp",
-          "required": false,
-          "visible": true,
-          "editable": true,
-          "value": "SPP-0",
-          "tooltip": "Name of the service protection profile",
-          "description": "Specify the name of the Service protection profile to add the new SPP policy to the FortiDDoS appliance.."
         },
         {
           "title": "Alternate SPP Enable",
@@ -1752,7 +1798,8 @@
                 "visible": true,
                 "editable": true,
                 "value": "1000000",
-                "description": "Specify the threshold per million that you want to add to the new SPP that you are adding to the FortiDDoS appliance."
+                "tooltip": "Range: 1 - 1000000",
+                "description": "Specify the threshold per million that you want to add to the new SPP that you are adding to the FortiDDoS appliance. Range: 1 - 1000000"
               }
             ],
             "false": [
@@ -1764,7 +1811,8 @@
                 "visible": true,
                 "editable": true,
                 "value": "1000000",
-                "description": "Specify threshold per million to add a new SPP policy in FortiDDoS."
+                "tooltip": "Range: 1 - 1000000",
+                "description": "Specify threshold per million to add a new SPP policy in FortiDDoS. Range: 1 - 1000000"
               }
             ]
           },
@@ -1858,6 +1906,7 @@
           "required": true,
           "visible": true,
           "editable": true,
+          "tooltip": "Specify the query to add the new Legitimate DNS Query into the FortiDDoS appliance.",
           "description": "Specify the query to add the new Legitimate DNS Query into the FortiDDoS appliance."
         },
         {
@@ -1868,17 +1917,19 @@
           "visible": true,
           "editable": true,
           "value": "1",
+          "tooltip": "Specify the type to add the new Legitimate DNS Query into the FortiDDoS appliance.",
           "description": "Specify the type to add the new Legitimate DNS Query into the FortiDDoS appliance."
         },
         {
           "title": "Class",
           "type": "text",
           "name": "class",
-          "required": false,
+          "required": true,
           "visible": true,
           "editable": true,
           "value": "1",
-          "description": "(Optional) Specify the class to add a new Legitimate DNS Query into the FortiDDoS appliance."
+          "tooltip": "Specify the class to add a new Legitimate DNS Query into the FortiDDoS appliance.",
+          "description": "Specify the class to add a new Legitimate DNS Query into the FortiDDoS appliance."
         }
       ]
     },

--- a/fortinet-fortiddos/info.json
+++ b/fortinet-fortiddos/info.json
@@ -1346,7 +1346,25 @@
           }
         },
         {
-          "condition": "{{this['subtype'] === 'top_attacks' || this['subtype'] === 'top_attacked_dns_servers' || this['subtype'] === 'top_attacked_dns_anomalies'}}",
+          "condition": "{{this['subtype'] === 'top_attacks'}}",
+          "output_schema": {
+            "data": [
+              {
+                "SPP": "",
+                "Drops": "",
+                "Attack": "",
+                "Events": "",
+                "spp-id": "",
+                "Direction": ""
+              }
+            ],
+            "total": "",
+            "success": "",
+            "message": ""
+          }
+        },
+        {
+          "condition": "{{this['subtype'] === 'top_attacked_dns_servers' || this['subtype'] === 'top_attacked_dns_anomalies'}}",
           "output_schema": {}
         }
       ]
@@ -1971,7 +1989,10 @@
           "description": "Specify the class for which you want to delete a legitimate DNS query that is present in the FortiDDoS appliance."
         }
       ],
-      "output_schema": {}
+      "output_schema": {
+        "status": "",
+        "message": ""
+      }
     },
     {
       "title": "Generate BGP Flowspec",

--- a/fortinet-fortiddos/update_service_protection_profile_settings.py
+++ b/fortinet-fortiddos/update_service_protection_profile_settings.py
@@ -4,7 +4,7 @@
   FORTINET CONFIDENTIAL & FORTINET PROPRIETARY SOURCE CODE
   Copyright end """
 from connectors.core.connector import get_logger, ConnectorError
-from .constants import LOGGER_NAME
+from .constants import LOGGER_NAME, RESOURCE_MAPPING, resources
 from .get_spp_settings import get_spp_settings
 from .utils import MakeRestApiCall
 import json
@@ -25,8 +25,12 @@ def update_service_protection_profile_settings(config, params):
     ddos_conn = MakeRestApiCall(config)
     ddos_conn.headers.update({'Accept': '*/*', 'Content-Type': 'application/json'})
     spp = params.get('spp')
-    endpoint = "/api/v2/spp/{spp_name}/ddos_spp_setting/".format(spp_name=spp)
+    if resource_name in resources:
+        resource_name = "SPP: {0}".format(resource_name)
+    endpoint = "/api/v2/spp/{spp_name}/{resource_name}/".format(spp_name=spp,
+                                                                resource_name=RESOURCE_MAPPING.get(resource_name,
+                                                                                                   resource_name))
     api_response = ddos_conn.make_request(method='PUT', endpoint=endpoint, data=rq)
     return {"status": "success",
-            "message": "{0} updated successfully.".format(resource_name)} if api_response == '' else {
-        "status": "failed", "message": "Failed to update {0}.".format(resource_name)}
+            "message": "{0} updated successfully.".format(params.get('resource_name'))} if api_response == '' else {
+        "status": "failed", "message": "Failed to update {0}.".format(params.get('resource_name'))}

--- a/fortinet-fortiddos/utils.py
+++ b/fortinet-fortiddos/utils.py
@@ -10,15 +10,8 @@ import json
 
 logger = get_logger(LOGGER_NAME)
 
-error_msg = {
-    401: 'Authentication failed due to invalid credentials',
-    404: 'Not Found',
-    "ssl_error": 'SSL certificate validation failed',
-    'time_out': 'The request timed out while trying to connect to the remote server',
-}
 
-
-class MakeRestApiCall():
+class MakeRestApiCall:
     def __init__(self, config):
         self.server_url = config.get('server_address').strip().strip('/')
         if not self.server_url.startswith('http') or not self.server_url.startswith('https'):
@@ -43,8 +36,10 @@ class MakeRestApiCall():
                 self.headers["Accept"] = "application/json"
             if headers: headers.update(self.headers)
             url = self.server_url + endpoint
-            logger.info('Requested url:{0}'.format(url))
-            response = requests.request(method=method, url=url, headers=headers if headers else self.headers, data=data, json=json_data,
+            logger.debug('Requested url:{0}'.format(url))
+            logger.debug('Payload data:{0}'.format(data))
+            response = requests.request(method=method, url=url, headers=headers if headers else self.headers, data=data,
+                                        json=json_data,
                                         params=params, verify=self.verify_ssl)
             if response.ok:
                 try:
@@ -62,7 +57,6 @@ class MakeRestApiCall():
             logger.exception('{0}'.format(e))
             raise ConnectorError('{0}'.format(error_msg.get('time_out')))
         except Exception as e:
-            logger.error('{0}'.format(e))
             raise ConnectorError('{0}'.format(e))
 
     def build_query(self, params, make_str=False):


### PR DESCRIPTION
PR details:

https://mantis.fortinet.com/bug_view_page.php?bug_id=0853337
Unit Test cases:
Check with Invalid Distress ACL
Check with valid Distress ACL
Fix: Retrieve all distress ACLs for validating whether the given user ACL name exists or not. If the ACL name is not in the retrieved list then raise the error with “{ACL_name} distress ACL name not exists."


For Source port:     https://mantis.fortinet.com/bug_view_page.php?bug_id=0853341
For Destination port (Duplicate):  https://mantis.fortinet.com/bug_view_page.php?bug_id=0852960
Unit Test cases:
Tested "Add Distress ACL” action with:
Check with Destination port to enable
	Destination Port Start
	Destination Port End
Check with source port to enable 
	Source Port Start
	Source Port End
Check with TTL value
Check with DSCP(ToS) enable and DSCP value ((ToS value)
Eg:
{
      "spp": "SPP-0",
      "ttl": false,
      "dscp": true,
      "mkey": "FortiSOAR_ACL112",
      "fragment": false,
      "protocol": false,
      "source-ip": false,
      "acl-enable": true,
      "dscp-value": 112,
      "destination": "all",
      "source-port": false,
      "destination-port": false,
      "tcp-control-flag": false,
      "threshold-per-million": 100000,
      "destination-ipv4-netmask": "0.0.0.0/0"
} 
Fix: Converted port integer values to string type. 



https://mantis.fortinet.com/bug_view_page.php?bug_id=0852043
Unit Test cases:
Tested with FortiDDoS IP with invalid server address/url. Eg: 172.30.153.160/ui/#navigate 
Check with valid server address
Fix:
Added error no in error_msg dict: 405: 'Method not allowed'




https://mantis.fortinet.com/bug_view_page.php?bug_id=0852959
Unit Test cases:
Check with All action params
Sample inputs:
{
      "spp": "SPP-0",
      "mkey": "FSR_SPP",
      "alt-spp": "SPP-0",
      "comment": "Added via FortiSOAR",
      "subnet-id": 1213,
      "ip-version": "IPv4",
      "ip-addr-mask": "192.3.2.5/24",
      "alt-spp-enable": true,
      "threshold-per-million": 1000000
    }
Fix: 
Set “ SPP” parameter as required in "Add Service Protection Profile Policy" action
Note:  if subnet-id wrong then API gives: 400 {\"success\":false,\"error_code\":\"-2118\"}



https://mantis.fortinet.com/bug_view_page.php?bug_id=0852919
Unit Test cases:
Check with Resource Name: GRE Tunnel Endpoint
Fix: Renamed Resource Name option “Service Provider Address" to "GRE Tunnel Endpoint" 


https://mantis.fortinet.com/bug_view_page.php?bug_id=0852947
Unit Test cases:
Check with all params:
{
      "type": 1,
      "class": 1,
      "query": "test_fsr.com"
}
Fix: Added JSON content-type header in add Legitimate DNS Query action request.


https://mantis.fortinet.com/bug_view_page.php?bug_id=0852917
Unit Test cases:
Check SPP and subtype params required
Fix: Added required true for SPP and subtype params.


https://mantis.fortinet.com/bug_view_page.php?bug_id=0853323 
Unit Test cases:
Check SYN Flood Mitigation Mode using 3 values.
"syn-flood-mitigation-mode": "syn-retransmission” /  “ack-cookie” /  “syn-cookie”
Fix: Not a bug.  Not working because passing syn-flood-mitigation-mode wrong value  as “ACK Cookie"


https://mantis.fortinet.com/bug_view_page.php?bug_id=0853327
https://mantis.fortinet.com/bug_view_page.php?bug_id=0853324
Unit Test cases:
Check Update SPP Settings action with 
	Resource name: Access Control List
	Resource Args: 
{
  "mkey": "fsr_acl",
  "type": "service",
  "service": "dsda",
  "direction": “outbound inbound",
  "service-action": "deny"
}
Fix: Updated resource name mapping in the update_service_protection_profile_settings function.



