### PR TITLE
Fixed bugs

### DIFF
--- a/fortinet-fortiddos/constants.py
+++ b/fortinet-fortiddos/constants.py
@@ -5,7 +5,7 @@
   Copyright end """
 LOGGER_NAME = 'fortinet-fortiddos'
 CONVERT_LIST = ['alt-spp-enable', 'acl-enable', 'destination-port', 'dscp', 'fragment', 'protocol', 'source-ip',
-                'source-port', 'tcp-control-flag', 'ttl']
+                'source-port', 'tcp-control-flag', 'ttl', 'destination']
 CONVERT_STR = ['destination-port-end', 'threshold-per-million', 'protocol-number', 'ttl-value', 'class', 'threshold',
                'subnet-id', 'destination-port-start', 'source-port-start', 'source-port-end', 'dscp-value']
 PARAM_MAPPING = {
@@ -17,8 +17,8 @@ PARAM_MAPPING = {
     'any-fragment': '4',
 
     # destination
-    'ip-netmask-ipv4': '1',
-    'all': '4'
+    'IPv4 Netmask': 'ip-netmask-v4',
+    'All': 'all'
 }
 RESOURCE_MAPPING = {
     #Protection Profiles Resource Mapping

--- a/fortinet-fortiddos/info.json
+++ b/fortinet-fortiddos/info.json
@@ -55,7 +55,7 @@
     {
       "title": "Get Protection Profiles",
       "operation": "get_spp_settings",
-      "description": "Retrieves the Protection Profiles details from the FortiDDoS appliance based on the Service Protection Profile (SPP) name and resource name you have specified.",
+      "description": "Retrieves the Protection Profiles details from the FortiDDoS appliance based on the Service Protection Profile (SPP) name and resource name you have specified. The protection profiles settings located at: Protection Profiles section.",
       "category": "investigation",
       "annotation": "get_spp_settings",
       "enabled": true,
@@ -183,9 +183,9 @@
       ]
     },
     {
-      "title": "Update SPP Settings",
+      "title": "Update Protection Profiles Settings",
       "operation": "update_service_protection_profile_settings",
-      "description": "Updates the SPP settings based on the SPP name, resource name, and resource arguments you have specified.",
+      "description": "Updates the protection profiles settings based on the SPP name, resource name, and resource arguments you have specified. The protection profiles settings located at: Protection Profiles section.",
       "category": "remediation",
       "annotation": "update_service_protection_profile_settings",
       "enabled": true,
@@ -417,7 +417,7 @@
     {
       "title": "Get Global Settings Address",
       "operation": "get_global_settings_address",
-      "description": "Retrieves the global setting address of the FortiDDoS appliance based on the resource name you have specified.",
+      "description": "Retrieves the global setting address of the FortiDDoS appliance based on the resource name you have specified. The global settings address is located at: Global Settings > Address.",
       "category": "investigation",
       "annotation": "get_global_settings",
       "enabled": true,
@@ -559,7 +559,7 @@
     {
       "title": "Get Proxy IP",
       "operation": "get_proxy_ip",
-      "description": "Retrieves the proxy IP details of the FortiDDoS appliance.",
+      "description": "Retrieves the proxy IP details of the FortiDDoS appliance. The proxy IP located at: Global Settings > Proxy IP.",
       "category": "investigation",
       "annotation": "get_global_settings",
       "enabled": true,
@@ -586,7 +586,7 @@
     {
       "title": "Get Proxy IP Policy",
       "operation": "get_proxy_ip_policy",
-      "description": "Retrieves the proxy IP policy details of the FortiDDoS appliance.",
+      "description": "Retrieves the proxy IP policy details of the FortiDDoS appliance. The proxy IP policy located at: Global Settings > Proxy IP Policy.",
       "category": "investigation",
       "annotation": "get_global_settings",
       "enabled": true,
@@ -601,7 +601,7 @@
     {
       "title": "Get Do Not Track Policy",
       "operation": "get_do_not_track_policy",
-      "description": "Retrieves the 'do not track policy' settings of the FortiDDoS appliance based on the resource name you have specified.",
+      "description": "Retrieves the 'do not track policy' settings of the FortiDDoS appliance based on the resource name you have specified. The do not track policy located at: Global Settings > Do Not Track Policy.",
       "category": "investigation",
       "annotation": "get_global_settings",
       "enabled": true,
@@ -637,7 +637,7 @@
     {
       "title": "Get Access Control List",
       "operation": "get_global_acl",
-      "description": "Retrieves the access control list details of global settings from the FortiDDoS appliance.",
+      "description": "Retrieves the access control list details of global settings from the FortiDDoS appliance. The access control list located at: Global Settings > Access Control List.",
       "category": "investigation",
       "annotation": "get_global_settings",
       "enabled": true,
@@ -716,7 +716,7 @@
     {
       "title": "Get Bypass MAC",
       "operation": "get_bypass_mac",
-      "description": "Retrieves the bypass MAC details of the FortiDDoS appliance.",
+      "description": "Retrieves the bypass MAC details of the FortiDDoS appliance. The bypass MAC details are located at: Global Settings > Bypass MAC.",
       "category": "investigation",
       "annotation": "get_global_settings",
       "enabled": true,
@@ -736,7 +736,7 @@
     {
       "title": "Get System Settings",
       "operation": "get_system_settings",
-      "description": "Retrieves the system settings information from FortiDDoS based on the resource name you have specified.",
+      "description": "Retrieves the system settings information from FortiDDoS based on the resource name you have specified. The system settings details are located at: System.",
       "category": "investigation",
       "annotation": "get_system_settings",
       "enabled": true,
@@ -772,6 +772,7 @@
                   "DNS",
                   "Static Route"
                 ],
+                "tooltip": "System > Network",
                 "description": "Select the name of the resource whose system settings you want to retrieve from FortiDDoS. You can choose from the following options: Interface, DNS, or Static Route."
               }
             ],
@@ -789,6 +790,7 @@
                   "Access Profile",
                   "Settings"
                 ],
+                "tooltip": "System > Admin",
                 "description": "Select the name of the resource whose system settings you want to retrieve from FortiDDoS. You can choose from the following options: Admin User, Access Profile, or Settings."
               }
             ],
@@ -806,6 +808,7 @@
                   "Auth LDAP",
                   "Auth TACACS+"
                 ],
+                "tooltip": "System > Authentication",
                 "description": "Select the name of the resource whose system settings you want to retrieve from FortiDDoS. You can choose from the following options: Auth Radius, Auth LDAP, Auth TACACS+"
               }
             ],
@@ -1121,7 +1124,7 @@
     {
       "title": "Get Log Settings",
       "operation": "get_log_settings",
-      "description": "Retrieves log information from the FortiDDoS appliance based on the resource name you have specified.",
+      "description": "Retrieves log information from the FortiDDoS appliance based on the resource name you have specified. The log settings details are located at: Log & Report > Log Configuration.",
       "category": "investigation",
       "annotation": "get_log_settings",
       "enabled": true,
@@ -1200,7 +1203,7 @@
     {
       "title": "Get Attack Information",
       "operation": "get_attack_information",
-      "description": "Retrieves attack information from FortiDDoS based on the SPP name, attack subtype, direction, and period you have specified.",
+      "description": "Retrieves attack information from FortiDDoS based on the SPP name, attack subtype, direction, and period you have specified. The attack information located at: Log & Report > Executive Summary.",
       "category": "investigation",
       "annotation": "get_attack_information",
       "enabled": true,
@@ -1372,7 +1375,7 @@
     {
       "title": "Add Distress ACL",
       "operation": "add_distress_acl",
-      "description": "Adds a new Distress ACL to the FortiDDoS appliance based on the Mkey, destination, and other input parameters you have specified.",
+      "description": "Adds a new Distress ACL to the FortiDDoS appliance based on the Mkey, destination, and other input parameters you have specified. The distress ACL located at: Global Settings > Access Control List > Advanced Settings > Distress ACL.",
       "category": "remediation",
       "annotation": "add_distress_acl",
       "enabled": true,
@@ -1404,12 +1407,12 @@
           "visible": true,
           "editable": true,
           "options": [
-            "ip-netmask-ipv4",
-            "all"
+            "IPv4 Netmask",
+            "All"
           ],
-          "value": "all",
+          "value": "All",
           "onchange": {
-            "ip-netmask-ipv4": [
+            "IPv4 Netmask": [
               {
                 "title": "Destination IPv4 Netmask",
                 "type": "text",
@@ -1422,7 +1425,7 @@
                 "description": "Specify the destination IPv4 Netmask to add to the new Distress ACL in the FortiDDoS. Example: 192.3.2.5/24"
               }
             ],
-            "all": [
+            "All": [
               {
                 "title": "SPP Name",
                 "type": "text",
@@ -1432,17 +1435,6 @@
                 "editable": true,
                 "value": "SPP-0",
                 "description": "Specify the SPP name to add to the new Distress ACL in the FortiDDoS."
-              },
-              {
-                "title": "Destination IPv4 Netmask",
-                "type": "text",
-                "name": "destination-ipv4-netmask",
-                "required": false,
-                "visible": true,
-                "editable": true,
-                "value": "0.0.0.0/0",
-                "tooltip": "Example: 192.3.2.5/24",
-                "description": "Specify the destination IPv4 Netmask to add to the new Distress ACL in the FortiDDoS. Example: 192.3.2.5/24"
               }
             ]
           },
@@ -1688,7 +1680,7 @@
     {
       "title": "Delete Distress ACL",
       "operation": "delete_distress_acl",
-      "description": "Deletes a specific Distress ACL from the FortiDDoS appliance based on the name of the distress ACL you have specified.",
+      "description": "Deletes a specific Distress ACL from the FortiDDoS appliance based on the name of the distress ACL you have specified. The distress ACL located at: Global Settings > Access Control List > Advanced Settings > Distress ACL.",
       "category": "remediation",
       "annotation": "delete_distress_acl",
       "enabled": true,
@@ -1855,7 +1847,7 @@
     {
       "title": "Get Service Protection Profile Policy",
       "operation": "get_service_protection_profile_policy",
-      "description": "Retrieves a list of all Service Protection Profile Policies from the FortiDDoS appliance.",
+      "description": "Retrieves a list of all Service Protection Profile Policies from the FortiDDoS appliance. The service protection profile policy details are located at: Global Settings > Service Protection Profiles > SPP Policy.",
       "category": "investigation",
       "annotation": "get_service_protection_profile_policy",
       "enabled": true,
@@ -1885,7 +1877,7 @@
     {
       "title": "Delete Service Protection Profile Policy",
       "operation": "delete_service_protection_profile_policy",
-      "description": "Deletes a specific Service Protection Profile Policy from the FortiDDoS appliance based on the name of the SPP policy you have specified.",
+      "description": "Deletes a specific Service Protection Profile Policy from the FortiDDoS appliance based on the name of the SPP policy you have specified. The service protection profile policy details are located at: Global Settings > Service Protection Profiles > SPP Policy.",
       "category": "remediation",
       "annotation": "delete_service_protection_profile_policy",
       "enabled": true,
@@ -1908,7 +1900,7 @@
     {
       "title": "Add Legitimate DNS Query",
       "operation": "add_lq",
-      "description": "Adds a new legitimate DNS Query to the FortiDDoS appliance based on the query, type, and other input parameters you have specified.",
+      "description": "Adds a new legitimate DNS Query to the FortiDDoS appliance based on the query, type, and other input parameters you have specified. The legitimate DNS query located at: Global Settings > Legitimate DNS Queries",
       "category": "remediation",
       "annotation": "add_lq",
       "enabled": true,
@@ -1954,7 +1946,7 @@
     {
       "title": "Delete Legitimate DNS Query",
       "operation": "delete_lq",
-      "description": "Deletes a specific legitimate DNS query from the FortiDDoS appliance based on the domain, type, and class you have specified.",
+      "description": "Deletes a specific legitimate DNS query from the FortiDDoS appliance based on the domain, type, and class you have specified. The legitimate DNS query located at: Global Settings > Legitimate DNS Queries",
       "category": "remediation",
       "annotation": "delete_lq",
       "enabled": true,
@@ -1997,7 +1989,7 @@
     {
       "title": "Generate BGP Flowspec",
       "operation": "generate_bgp_flowspec",
-      "description": "Generate BGP flow specifications based on the vendor name, destination under attack, and threshold you have specified.",
+      "description": "Generate BGP flow specifications based on the vendor name, destination under attack, and threshold you have specified. The generated BGP flowspec located at: Log & Report > Flowspec.",
       "category": "containment",
       "annotation": "generate_bgp_flowspec",
       "enabled": true,

--- a/fortinet-fortiddos/playbooks/playbooks.json
+++ b/fortinet-fortiddos/playbooks/playbooks.json
@@ -18,7 +18,7 @@
           "uuid": "ace529e2-939f-46b5-85af-d9c8481b6d7e",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Retrieves the Protection Profiles details from the FortiDDoS appliance based on the Service Protection Profile (SPP) name and resource name you have specified.",
+          "description": "Retrieves the Protection Profiles details from the FortiDDoS appliance based on the Service Protection Profile (SPP) name and resource name you have specified. The protection profiles settings located at: Protection Profiles section.",
           "name": "Get Protection Profiles",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -101,8 +101,8 @@
           "uuid": "34a29aa3-20c1-4769-ac93-d92f3af14b63",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Updates the SPP settings based on the SPP name, resource name, and resource arguments you have specified.",
-          "name": "Update SPP Settings",
+          "description": "Updates the protection profiles settings based on the SPP name, resource name, and resource arguments you have specified. The protection profiles settings located at: Protection Profiles section.",
+          "name": "Update Protection Profiles Settings",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
             "Fortinet",
@@ -123,7 +123,7 @@
               "status": null,
               "arguments": {
                 "route": "adb558c2-32c5-43d5-a7b0-4e762768c717",
-                "title": "Fortinet FortiDDoS: Update SPP Settings",
+                "title": "Fortinet FortiDDoS: Update Protection Profiles Settings",
                 "resources": [
                   "alerts"
                 ],
@@ -144,7 +144,7 @@
             {
               "uuid": "2b6d282f-366a-42c2-a176-78ba26fca81f",
               "@type": "WorkflowStep",
-              "name": "Update SPP Settings",
+              "name": "Update Protection Profiles Settings",
               "description": null,
               "status": null,
               "arguments": {
@@ -160,7 +160,7 @@
                 "version": "1.0.0",
                 "connector": "fortinet-fortiddos",
                 "operation": "update_service_protection_profile_settings",
-                "operationTitle": "Update SPP Settings",
+                "operationTitle": "Update Protection Profiles Settings",
                 "step_variables": {
                   "output_data": "{{vars.result}}"
                 }
@@ -176,7 +176,7 @@
               "uuid": "92e87111-6ecf-4da9-beb6-78558ed076e0",
               "label": null,
               "isExecuted": false,
-              "name": "Start-> Update SPP Settings",
+              "name": "Start-> Update Protection Profiles Settings",
               "sourceStep": "/api/3/workflow_steps/79e33dca-69f2-4810-a964-c4c6c797d0c2",
               "targetStep": "/api/3/workflow_steps/2b6d282f-366a-42c2-a176-78ba26fca81f"
             }
@@ -349,7 +349,7 @@
           "uuid": "1f1ed298-cd61-4e0f-8fbd-16a22fed89c1",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Retrieves the internal sub-resources from settings in the FortiDDoS global settings based on the resource name you have specified.",
+          "description": "Retrieves the internal sub-resources from settings in the FortiDDoS global settings based on the resource name you have specified. The global settings are located at: Global Settings > Settings.",
           "name": "Get Settings",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -431,7 +431,7 @@
           "uuid": "1f1fc426-b28c-4ac3-8d83-1e8b2977ef82",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Retrieves the global setting address of the FortiDDoS appliance based on the resource name you have specified.",
+          "description": "Retrieves the global setting address of the FortiDDoS appliance based on the resource name you have specified. The global settings address is located at: Global Settings > Address.",
           "name": "Get Global Settings Address",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -673,7 +673,7 @@
           "uuid": "b6a809dd-efac-4243-b3d2-9a9cc6aea712",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Retrieves the proxy IP details of the FortiDDoS appliance.",
+          "description": "Retrieves the proxy IP details of the FortiDDoS appliance. The proxy IP located at: Global Settings > Proxy IP.",
           "name": "Get Proxy IP",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -753,7 +753,7 @@
           "uuid": "01f247f0-65a0-4438-857d-28d376a297d3",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Retrieves the proxy IP policy details of the FortiDDoS appliance.",
+          "description": "Retrieves the proxy IP policy details of the FortiDDoS appliance. The proxy IP policy located at: Global Settings > Proxy IP Policy.",
           "name": "Get Proxy IP Policy",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -833,7 +833,7 @@
           "uuid": "26748f54-1c4d-4644-b6e9-5a6a4121e87c",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Retrieves the 'do not track policy' settings of the FortiDDoS appliance based on the resource name you have specified.",
+          "description": "Retrieves the 'do not track policy' settings of the FortiDDoS appliance based on the resource name you have specified. The do not track policy located at: Global Settings > Do Not Track Policy.",
           "name": "Get Do Not Track Policy",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -915,7 +915,7 @@
           "uuid": "ec706b51-c46e-4ce8-a5ec-c1072214bf37",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Retrieves the access control list details of global settings from the FortiDDoS appliance.",
+          "description": "Retrieves the access control list details of global settings from the FortiDDoS appliance. The access control list located at: Global Settings > Access Control List.",
           "name": "Get Access Control List",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -997,7 +997,7 @@
           "uuid": "80ff46c6-8767-4813-9161-7d4eee5b7ad7",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Retrieves the bypass MAC details of the FortiDDoS appliance.",
+          "description": "Retrieves the bypass MAC details of the FortiDDoS appliance. The bypass MAC details are located at: Global Settings > Bypass MAC.",
           "name": "Get Bypass MAC",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -1077,7 +1077,7 @@
           "uuid": "44fc396f-1e83-4630-a5f7-2e9514b7be6e",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Retrieves the system settings information from FortiDDoS based on the resource name you have specified.",
+          "description": "Retrieves the system settings information from FortiDDoS based on the resource name you have specified. The system settings details are located at: System.",
           "name": "Get System Settings",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -1160,7 +1160,7 @@
           "uuid": "51bf1998-a40f-4935-8fb9-9c0aed27572d",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Retrieves log information from the FortiDDoS appliance based on the resource name you have specified.",
+          "description": "Retrieves log information from the FortiDDoS appliance based on the resource name you have specified. The log settings details are located at: Log & Report > Log Configuration.",
           "name": "Get Log Settings",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -1242,7 +1242,7 @@
           "uuid": "07c0f162-7aa3-4187-a7e3-2c971c7326d2",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Retrieves all attack information or specific attack information from FortiDDoS based on the SPP Name, Direction, and Period you have specified.",
+          "description": "Retrieves attack information from FortiDDoS based on the SPP name, attack subtype, direction, and period you have specified. The attack information located at: Log & Report > Executive Summary.",
           "name": "Get Attack Information",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -1327,7 +1327,7 @@
           "uuid": "79b8998c-6e22-465d-ba86-a54e6c62493d",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Adds a new Distress ACL to the FortiDDoS appliance based on the Mkey, destination, and other input parameters you have specified.",
+          "description": "Adds a new Distress ACL to the FortiDDoS appliance based on the Mkey, destination, and other input parameters you have specified. The distress ACL located at: Global Settings > Access Control List > Advanced Settings > Distress ACL.",
           "name": "Add Distress ACL",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -1377,7 +1377,7 @@
                 "name": "Fortinet FortiDDoS",
                 "config": "",
                 "params": {
-                  "destination": "all",
+                  "destination": "All",
                   "destination-port": false,
                   "dscp": false,
                   "fragment": false,
@@ -1389,8 +1389,7 @@
                   "spp": "SPP-0",
                   "mkey": "FortiSOAR_ACL",
                   "acl-enable": true,
-                  "threshold-per-million": 100000,
-                  "destination-ipv4-netmask": "0.0.0.0/0"
+                  "threshold-per-million": 100000
                 },
                 "version": "1.0.0",
                 "connector": "fortinet-fortiddos",
@@ -1422,7 +1421,7 @@
           "uuid": "016f5c2c-2829-4f24-a005-120b431c5f1b",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Deletes a specific Distress ACL from the FortiDDoS appliance based on the name of the distress ACL you have specified.",
+          "description": "Deletes a specific Distress ACL from the FortiDDoS appliance based on the name of the distress ACL you have specified. The distress ACL located at: Global Settings > Access Control List > Advanced Settings > Distress ACL.",
           "name": "Delete Distress ACL",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -1502,7 +1501,7 @@
           "uuid": "56a594b7-164b-4e73-9737-2f02d4a9b2c0",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Adds a new SPP profile to the FortiDDoS appliance based on subnet ID, Mkey name, IP version, and the input parameters you have specified.",
+          "description": "Adds a new SPP Policy to the FortiDDoS appliance based on subnet ID, Mkey name, IP version, and the input parameters you have specified. The new SPP policy details are located at: Global Settings > Service Protection Profiles > SPP Policy.",
           "name": "Add Service Protection Profile Policy",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -1587,7 +1586,7 @@
           "uuid": "d6012e9a-8f7e-4ebf-840f-f3f5af1ca54f",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Retrieves a list of all Service Protection Profile Policies from the FortiDDoS appliance.",
+          "description": "Retrieves a list of all Service Protection Profile Policies from the FortiDDoS appliance. The service protection profile policy details are located at: Global Settings > Service Protection Profiles > SPP Policy.",
           "name": "Get Service Protection Profile Policy",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -1667,7 +1666,7 @@
           "uuid": "f2d7eb6b-6425-4ee4-8335-1254a4a720f3",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Deletes a specific Service Protection Profile Policy from the FortiDDoS appliance based on the name of the SPP policy you have specified.",
+          "description": "Deletes a specific Service Protection Profile Policy from the FortiDDoS appliance based on the name of the SPP policy you have specified. The service protection profile policy details are located at: Global Settings > Service Protection Profiles > SPP Policy.",
           "name": "Delete Service Protection Profile Policy",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -1747,7 +1746,7 @@
           "uuid": "5e19e1f5-2346-4b78-92ac-189ec7a02df8",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Adds a new legitimate DNS Query to the FortiDDoS appliance based on the query, type, and other input parameters you have specified.",
+          "description": "Adds a new legitimate DNS Query to the FortiDDoS appliance based on the query, type, and other input parameters you have specified. The legitimate DNS query located at: Global Settings > Legitimate DNS Queries",
           "name": "Add Legitimate DNS Query",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -1831,7 +1830,7 @@
           "uuid": "d054a2c8-b4e3-4dcb-8829-0c8bc8eae6ce",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Deletes a specific legitimate DNS query from the FortiDDoS appliance based on the domain, type, and class you have specified.",
+          "description": "Deletes a specific legitimate DNS query from the FortiDDoS appliance based on the domain, type, and class you have specified. The legitimate DNS query located at: Global Settings > Legitimate DNS Queries",
           "name": "Delete Legitimate DNS Query",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [
@@ -1915,7 +1914,7 @@
           "uuid": "aeaedaf1-bfcf-4c4f-86e1-bc5cb801a8a9",
           "collection": "/api/3/workflow_collections/7997ab76-41ab-4642-93cd-b648dc3da858",
           "triggerLimit": null,
-          "description": "Generate BGP flow specifications based on the vendor name, destination under attack, and threshold you have specified.",
+          "description": "Generate BGP flow specifications based on the vendor name, destination under attack, and threshold you have specified. The generated BGP flowspec located at: Log & Report > Flowspec.",
           "name": "Generate BGP Flowspec",
           "tag": "#Fortinet FortiDDoS",
           "recordTags": [

--- a/fortinet-fortiddos/utils.py
+++ b/fortinet-fortiddos/utils.py
@@ -37,7 +37,6 @@ class MakeRestApiCall:
             if headers: headers.update(self.headers)
             url = self.server_url + endpoint
             logger.debug('Requested url:{0}'.format(url))
-            logger.debug('Payload data:{0}'.format(data))
             response = requests.request(method=method, url=url, headers=headers if headers else self.headers, data=data,
                                         json=json_data,
                                         params=params, verify=self.verify_ssl)


### PR DESCRIPTION
PR details:

https://mantis.fortinet.com/bug_view_page.php?bug_id=0857698
Unit Test cases:
Check with all action params
Eg: {"data": {"spp": "SPP-0", "ttl": "enable", "dscp": "disable", "mkey": "test1192", "fragment": "disable", "protocol": "disable", "source-ip": "enable", "ttl-value": "22", "acl-enable": "disable", "destination": "all", "source-port": "enable", "source-port-end": "13", "destination-port": "disable", "tcp-control-flag": "disable", "source-port-start": "12", "source-ipv4-netmask": "195.3.2.5/24", "threshold-per-million": "1000000", "system-generated": "disable"}}
Fix:  
Removed "Destination IPv4 netmask" for "destination" dropdown is selected as ALL
Renamed destination parameter options as: "IPv4 Netmask", "All"
Renamed action from "Update SPP settings" to "Update Protection Profile settings" 

https://mantis.fortinet.com/bug_view_page.php?bug_id=0857354
Unit Test cases:
Check all action descriptions with the navigation.
Check all playbook descriptions with the navigation.
Fix :
Updated all actions and PBs description.

